### PR TITLE
Support mapping navigation properties from readers

### DIFF
--- a/DBEngine/DBEngine-ObjectFromReader.cs
+++ b/DBEngine/DBEngine-ObjectFromReader.cs
@@ -94,20 +94,32 @@ namespace MDDDataAccess
         }
         private void BuildPropertyMap<T>(SqlDataReader rdr, ref List<PropertyMapEntry> map, ref PropertyInfo key, bool strict, PropertyInfo concurrencyproperty)
         {
-            map = new List<PropertyMapEntry>();
+            var columnOrdinals = GetColumnOrdinals(rdr);
+            var visited = new HashSet<Type>();
 
-            var ColumOrdinals = GetColumnOrdinals(rdr);
+            map = BuildPropertyMapInternal(typeof(T), rdr, columnOrdinals, strict, concurrencyproperty, visited, true, ref key);
 
+            map.Sort((x, y) => x.Ordinal.CompareTo(y.Ordinal));
+        }
 
-            foreach (var item in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(x => x.CanWrite))
+        private List<PropertyMapEntry> BuildPropertyMapInternal(Type targetType, SqlDataReader rdr, Dictionary<string, Queue<int>> columnOrdinals, bool strict, PropertyInfo concurrencyProperty, HashSet<Type> recursionStack, bool isRoot, ref PropertyInfo key)
+        {
+            var result = new List<PropertyMapEntry>();
+
+            if (!recursionStack.Add(targetType))
+                return result;
+
+            foreach (var item in targetType.GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(x => x.CanWrite))
             {
                 var type = item.PropertyType;
                 if (type.IsValueType || type == typeof(string) || type.IsArray)
                 {
-                    var entry = new PropertyMapEntry();
-                    entry.Optional = !item.GetSetMethod(true).IsPublic;
-                    entry.ColumnName = item.Name;
-                    entry.Property = item;
+                    var entry = new PropertyMapEntry
+                    {
+                        Optional = !item.GetSetMethod(true).IsPublic,
+                        ColumnName = item.Name,
+                        Property = item
+                    };
                     bool include = true;
                     bool special = false;
                     foreach (var attr in item.GetCustomAttributes(true))
@@ -118,14 +130,10 @@ namespace MDDDataAccess
                             entry.ColumnName = dbna.DBName;
                         if (attr is DBOptionalAttribute)
                             entry.Optional = true;
-                        if (attr is ListKeyAttribute)
+                        if (attr is ListKeyAttribute && isRoot)
                             key = item;
                         if (attr is DBLoadedTimeAttribute)
                         {
-                            //include = false;
-                            //nomap = true;
-                            //map = null;
-                            //item.SetValue(r, DateTime.Now);
                             special = true;
                             entry.Ordinal = -100;
                             entry.MapAction = BuildStaticDateTimeFunc(item);
@@ -133,13 +141,18 @@ namespace MDDDataAccess
                     }
                     if (include && !special)
                     {
-                        if (!strict) entry.Optional = item != concurrencyproperty;
-                        if (ColumOrdinals.TryGetValue(entry.ColumnName, out var ordinals))
+                        if (!strict)
                         {
-                            entry.Ordinal = ordinals[0];
-                            //when building a map for a single object, any given column should only appear once but I don't necessarily
-                            //want to throw if it has more than one - I may have a version of BuildPropertyMap that handles 2 types - then things get a little
-                            //more interesting with columns like created_date / modified_date - for now, I'll just end up using the first one I find
+                            if (concurrencyProperty != null)
+                                entry.Optional = item != concurrencyProperty;
+                            else
+                                entry.Optional = true;
+                        }
+                        if (columnOrdinals.TryGetValue(entry.ColumnName, out var ordinals) && ordinals.Count > 0)
+                        {
+                            entry.Ordinal = ordinals.Dequeue();
+                            if (ordinals.Count == 0)
+                                columnOrdinals.Remove(entry.ColumnName);
                         }
                         else
                         {
@@ -148,9 +161,9 @@ namespace MDDDataAccess
                                     item.Name,
                                     item.PropertyType.FullName,
                                     entry.ColumnName,
-                                    typeof(T).Name,
+                                    targetType.Name,
                                     entry.Optional,
-                                    $"DBEngine internal error: The column '{entry.ColumnName}' was specified as a property (or DBName attribute) in the '{typeof(T).Name}' object but was not found in a query meant to populate objects of that type. " +
+                                    $"DBEngine internal error: The column '{entry.ColumnName}' was specified as a property (or DBName attribute) in the '{targetType.Name}' object but was not found in a query meant to populate objects of that type. " +
                                     "You must either decorate this property with a DBIgnore attribute if you want ObjectFromReader to always ignore it, or a DBOptional attribute if you want ObjectFromReader to use it if it is there, but ignore it if it is not."
                                 );
                             else
@@ -162,19 +175,75 @@ namespace MDDDataAccess
                             BuildCompiledMap(entry);
                         }
                     }
-                    if (include) map.Add(entry);
+                    if (include) result.Add(entry);
                 }
                 else
                 {
-                    if (DebugLevel > 100)
+                    if (!type.IsClass || type == typeof(string) || type.IsAbstract)
                     {
-                        if (unhandledtypesreported.TryAdd($"{typeof(T).Name}.{item.Name}", true))
-                            Log.Entry("ObjectFromReader", 50, $"Unhandled type in {typeof(T).Name}.{item.Name} type full name: {type.FullName}", "");
+                        if (DebugLevel > 100)
+                        {
+                            if (unhandledtypesreported.TryAdd($"{targetType.Name}.{item.Name}", true))
+                                Log.Entry("ObjectFromReader", 50, $"Unhandled type in {targetType.Name}.{item.Name} type full name: {type.FullName}", "");
+                        }
+                        continue;
                     }
-                    //what to do with this type?
+
+                    if (type.GetConstructor(Type.EmptyTypes) == null)
+                    {
+                        if (DebugLevel > 100)
+                        {
+                            if (unhandledtypesreported.TryAdd($"{targetType.Name}.{item.Name}", true))
+                                Log.Entry("ObjectFromReader", 50, $"Unhandled type in {targetType.Name}.{item.Name} type full name: {type.FullName}", "");
+                        }
+                        continue;
+                    }
+
+                    var clonedOrdinals = CloneColumnOrdinals(columnOrdinals);
+                    PropertyInfo childKey = null;
+                    var childMap = BuildPropertyMapInternal(type, rdr, clonedOrdinals, false, null, recursionStack, false, ref childKey);
+
+                    if (childMap.Count == 0)
+                        continue;
+
+                    ReplaceColumnOrdinals(columnOrdinals, clonedOrdinals);
+
+                    var navigationEntry = new PropertyMapEntry
+                    {
+                        Property = item,
+                        Optional = true,
+                        ColumnName = item.Name,
+                        ChildMap = childMap
+                    };
+
+                    var ord = childMap.Where(m => m.Ordinal >= 0).Select(m => m.Ordinal);
+                    navigationEntry.Ordinal = ord.Any() ? ord.Min() : int.MaxValue;
+
+                    navigationEntry.MapAction = (reader, target) =>
+                    {
+                        bool hasValue = childMap.Any(cm => cm.Ordinal >= 0 && !reader.IsDBNull(cm.Ordinal));
+                        if (!hasValue)
+                            return;
+
+                        var current = item.GetValue(target);
+                        if (current == null)
+                        {
+                            current = Activator.CreateInstance(type);
+                            item.SetValue(target, current);
+                        }
+
+                        ExecutePropertyMap(reader, childMap, current, type);
+                    };
+
+                    result.Add(navigationEntry);
                 }
             }
-            map.Sort((x, y) => x.Ordinal.CompareTo(y.Ordinal));
+
+            recursionStack.Remove(targetType);
+
+            result.Sort((x, y) => x.Ordinal.CompareTo(y.Ordinal));
+
+            return result;
         }
         private readonly ConcurrentDictionary<string,bool> unhandledtypesreported = new ConcurrentDictionary<string,bool>();
         private void ExecutePropertyMap<T>(SqlDataReader rdr, List<PropertyMapEntry> map, T target) where T : class
@@ -201,9 +270,42 @@ namespace MDDDataAccess
                         target,
                         entry.Property.Name,
                         entry.Property.PropertyType.FullName,
-                        entry.ReaderType.Name,
+                        entry.ReaderType?.Name ?? "<unknown>",
                         objectvalues,
-                        $"DBEngine internal error: Post-mapping error occurred trying to set {target.GetType().Name}.{entry.Property.Name} - {entry.ReaderType.Name} -> {entry.Property.PropertyType.FullName}",
+                        $"DBEngine internal error: Post-mapping error occurred trying to set {target.GetType().Name}.{entry.Property.Name} - {(entry.ReaderType == null ? "<unknown>" : entry.ReaderType.Name)} -> {entry.Property.PropertyType.FullName}",
+                        ex
+                    );
+                }
+            }
+        }
+
+        private void ExecutePropertyMap(SqlDataReader rdr, List<PropertyMapEntry> map, object target, Type targetType)
+        {
+            foreach (var entry in map)
+            {
+                try
+                {
+                    entry.MapAction(rdr, target);
+                }
+                catch (Exception ex)
+                {
+                    string objectvalues = null;
+                    try
+                    {
+                        objectvalues = string.Join("\r", targetType.GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(pi => $"{pi.Name}={(pi.GetValue(target) == null ? "<null>" : pi.GetValue(target).ToString())}"));
+                    }
+                    catch (Exception ex2)
+                    {
+                        objectvalues = $"Error getting object values: {ex2.Message}";
+                    }
+
+                    throw new DBEnginePostMappingException<object>(
+                        target,
+                        entry.Property.Name,
+                        entry.Property.PropertyType.FullName,
+                        entry.ReaderType?.Name ?? "<unknown>",
+                        objectvalues,
+                        $"DBEngine internal error: Post-mapping error occurred trying to set {targetType.Name}.{entry.Property.Name} - {(entry.ReaderType == null ? "<unknown>" : entry.ReaderType.Name)} -> {entry.Property.PropertyType.FullName}",
                         ex
                     );
                 }
@@ -418,6 +520,21 @@ namespace MDDDataAccess
             }
         }
 
+        private static Dictionary<string, Queue<int>> CloneColumnOrdinals(Dictionary<string, Queue<int>> source)
+        {
+            var clone = new Dictionary<string, Queue<int>>(source.Comparer);
+            foreach (var kvp in source)
+                clone[kvp.Key] = new Queue<int>(kvp.Value);
+            return clone;
+        }
+
+        private static void ReplaceColumnOrdinals(Dictionary<string, Queue<int>> target, Dictionary<string, Queue<int>> source)
+        {
+            target.Clear();
+            foreach (var kvp in source)
+                target[kvp.Key] = new Queue<int>(kvp.Value);
+        }
+
         private static void BuildCompiledMap_old(PropertyMapEntry entry)
         {
             var targetType = entry.Property.DeclaringType;
@@ -567,18 +684,18 @@ namespace MDDDataAccess
             var lambda = Expression.Lambda<Action<SqlDataReader, object>>(setExp, readerParam, targetParam);
             entry.MapAction = lambda.Compile();
         }
-        private static Dictionary<string, List<int>> GetColumnOrdinals(SqlDataReader rdr)
+        private static Dictionary<string, Queue<int>> GetColumnOrdinals(SqlDataReader rdr)
         {
-            var dict = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
+            var dict = new Dictionary<string, Queue<int>>(StringComparer.OrdinalIgnoreCase);
             for (int i = 0; i < rdr.FieldCount; i++)
             {
                 var name = rdr.GetName(i);
                 if (!dict.TryGetValue(name, out var list))
                 {
-                    list = new List<int>();
+                    list = new Queue<int>();
                     dict[name] = list;
                 }
-                list.Add(i);
+                list.Enqueue(i);
             }
             return dict;
         }
@@ -693,6 +810,7 @@ namespace MDDDataAccess
         public PropertyInfo Property { get; set; }
         public string ColumnName { get; set; }
         public bool Optional { get; set; }
+        public List<PropertyMapEntry> ChildMap { get; set; }
         public override string ToString() => $"rdr({Ordinal}): rdr({ColumnName}) -> {Property.Name} - {Property.PropertyType.Name}";
     }
 }

--- a/DBEngineUnitTests/UnitTest1.cs
+++ b/DBEngineUnitTests/UnitTest1.cs
@@ -1,6 +1,7 @@
 ﻿using MDDDataAccess;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Linq;
 
 namespace DBEngineUnitTests
 {
@@ -13,18 +14,33 @@ namespace DBEngineUnitTests
         [TestInitialize]
         public void Initialize() 
         {
-            var script = @"IF DB_ID() <> 2 
+            var script = @"IF DB_ID() <> 2
 BEGIN
-	SET NOEXEC ON;
-	RAISERROR('You should be running this on tempdb',16,1);
+        SET NOEXEC ON;
+        RAISERROR('You should be running this on tempdb',16,1);
 END;
 IF OBJECT_ID('dbo.OrderDetails') IS NOT NULL DROP TABLE OrderDetails;
 IF OBJECT_ID('dbo.Item') IS NOT NULL DROP TABLE Item;
+IF OBJECT_ID('dbo.Category') IS NOT NULL DROP TABLE Category;
 
+CREATE TABLE Category (
+        CategoryId INT PRIMARY KEY IDENTITY(301,1),
+        CategoryName VARCHAR(100) NOT NULL,
+        modified_date DATETIME
+);
+GO
+CREATE TRIGGER trgCategory ON dbo.Category
+FOR UPDATE
+AS
+UPDATE tgt SET tgt.modified_date = GETDATE()
+FROM Inserted i
+        JOIN dbo.Category tgt ON tgt.CategoryId = i.CategoryId
+GO
 CREATE TABLE Item (
-	ItemId INT PRIMARY KEY IDENTITY(101,1),
-	ItemName VARCHAR(100) NOT NULL,
-	modified_date DATETIME
+        ItemId INT PRIMARY KEY IDENTITY(101,1),
+        ItemName VARCHAR(100) NOT NULL,
+        CategoryId INT NOT NULL FOREIGN KEY REFERENCES dbo.Category (CategoryId),
+        modified_date DATETIME
 );
 GO
 CREATE TRIGGER trgItem ON dbo.Item
@@ -50,21 +66,83 @@ FROM Inserted i
 	JOIN dbo.OrderDetails tgt ON tgt.OrderDetailId = i.OrderDetailId
 GO
 
-INSERT dbo.Item (ItemName) VALUES ('Table'),('Chair');
+INSERT dbo.Category (CategoryName) VALUES ('Furniture'),('Office');
+
+INSERT dbo.Item (ItemName, CategoryId)
+SELECT 'Table', CategoryId FROM dbo.Category WHERE CategoryName = 'Furniture';
+INSERT dbo.Item (ItemName, CategoryId)
+SELECT 'Chair', CategoryId FROM dbo.Category WHERE CategoryName = 'Office';
 
 INSERT dbo.OrderDetails (OrderId, OrderQty, ItemId)
-SELECT 501, 2, ItemId FROM dbo.Item;";
+SELECT 501, 2, ItemId FROM dbo.Item;
+
+UPDATE dbo.Category SET CategoryName = CategoryName;
+UPDATE dbo.Item SET ItemName = ItemName;
+UPDATE dbo.OrderDetails SET OrderQty = OrderQty;";
             _db = new DBEngine(ConnString, "NavigationPropertyTesting") { AllowAdHoc = true, Tracking = ObjectTracking.IfAvailable };
             _db.ExecuteScript(script);
         }
         [TestMethod]
         public void NavigationPropertiesPopulateWhenTheQueryIncludesTheirColumns()
         {
-            string query = "SELECT * FROM dbo.OrderDetails od JOIN dbo.Item i ON i.ItemId = od.ItemId";
+            string query = "SELECT * FROM dbo.OrderDetails od JOIN dbo.Item i ON i.ItemId = od.ItemId ORDER BY od.OrderDetailId";
             var od = _db.SqlRunQueryWithResults<OrderDetails>(query, false);
             Assert.IsNotNull(od);
             Assert.AreEqual(od.Count, 2);
             Assert.IsNotNull(od[0].OrderItem);
+            Assert.IsNotNull(od[1].OrderItem);
+            Assert.IsTrue(od.All(x => x.OrderItem.Category == null));
+        }
+
+        [TestMethod]
+        public void NavigationPropertiesRemainNullWhenTheQueryDoesNotIncludeTheirColumns()
+        {
+            string query = "SELECT * FROM dbo.OrderDetails";
+            var od = _db.SqlRunQueryWithResults<OrderDetails>(query, false);
+            Assert.IsNotNull(od);
+            Assert.AreEqual(od.Count, 2);
+            Assert.IsTrue(od.All(x => x.OrderItem == null));
+        }
+
+        [TestMethod]
+        public void NavigationPropertiesAreNotInstantiatedWhenJoinedColumnsAreNull()
+        {
+            string query = @"SELECT od.OrderDetailId, od.OrderId, od.OrderQty, od.ItemId, od.modified_date,
+                                    child.ItemId, child.ItemName, child.CategoryId, child.modified_date
+                             FROM dbo.OrderDetails od
+                             LEFT JOIN dbo.Item child ON 1 = 0
+                             ORDER BY od.OrderDetailId";
+            var od = _db.SqlRunQueryWithResults<OrderDetails>(query, false);
+            Assert.IsNotNull(od);
+            Assert.AreEqual(od.Count, 2);
+            Assert.IsTrue(od.All(x => x.OrderItem == null));
+        }
+
+        [TestMethod]
+        public void NavigationPropertyConcurrencyColumnsAreMappedIndependently()
+        {
+            string query = "SELECT * FROM dbo.OrderDetails od JOIN dbo.Item i ON i.ItemId = od.ItemId ORDER BY od.OrderDetailId";
+            var od = _db.SqlRunQueryWithResults<OrderDetails>(query, false);
+            Assert.IsNotNull(od);
+            Assert.IsTrue(od.All(x => x.modified_date.HasValue));
+            Assert.IsTrue(od.All(x => x.OrderItem != null && x.OrderItem.modified_date.HasValue));
+        }
+
+        [TestMethod]
+        public void NestedNavigationPropertiesPopulateWhenColumnsAreProvided()
+        {
+            string query = @"SELECT *
+                             FROM dbo.OrderDetails od
+                             JOIN dbo.Item i ON i.ItemId = od.ItemId
+                             JOIN dbo.Category c ON c.CategoryId = i.CategoryId
+                             ORDER BY od.OrderDetailId";
+            var od = _db.SqlRunQueryWithResults<OrderDetails>(query, false);
+            Assert.IsNotNull(od);
+            Assert.AreEqual(od.Count, 2);
+            Assert.IsTrue(od.All(x => x.OrderItem != null));
+            Assert.IsTrue(od.All(x => x.OrderItem.Category != null));
+            var categories = od.Select(x => x.OrderItem.Category.CategoryName).ToList();
+            CollectionAssert.AreEquivalent(new[] { "Furniture", "Office" }, categories);
         }
         private class OrderDetails
         {
@@ -82,6 +160,16 @@ SELECT 501, 2, ItemId FROM dbo.Item;";
             [ListKey]
             public int ItemId { get; set; }
             public string ItemName { get; set; }
+            public int CategoryId { get; set; }
+            [ListConcurrency]
+            public DateTime? modified_date { get; set; }
+            public Category Category { get; set; }
+        }
+        private class Category
+        {
+            [ListKey]
+            public int CategoryId { get; set; }
+            public string CategoryName { get; set; }
             [ListConcurrency]
             public DateTime? modified_date { get; set; }
         }


### PR DESCRIPTION
## Summary
- update BuildPropertyMap to recursively build child maps for navigation properties
- track duplicate column ordinals so joined column sets can populate nested objects
- extend execution pipeline to map child objects and handle errors for nested mappings
- add navigation property regression tests covering null joins and nested relationships

## Testing
- not run (dotnet command unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dac1a1687c832488ddce91f4e7625e